### PR TITLE
Use rough estimate of rupture length as basis for default distances.

### DIFF
--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -107,9 +107,21 @@ var EditPane = function (options) {
 
     mag = mainshock.properties.mag;
 
+    /* 
+     * Default values for aftershock and historical seismicity differences are 
+     * based on rupture length, which we estimate from the Hanks-Bakun (2014) 
+     * magitude-area relation. We round to the nearest 10km via 10*round(0.1*value).
+     *
+     * A = 10**(M-4), L(approx) = A**0.7
+     * 
+     * Aftershock distance = L, historical distance = 1.5*L
+     */
+      var A = Math.pow(10, mag-4);
+      var L = Math.pow(A, 0.7);
+
     return {
-      'aftershocks-dist': Math.max(5, Math.round(mag - 2) * 5),
-      'historical-dist': Math.max(10, Math.round(mag - 2) * 10),
+      'aftershocks-dist': Math.max(5, 10*Math.round(0.1*L)),
+      'historical-dist': Math.max(10, 15*Math.round(0.1*L)),
       'historical-years': 10
     };
   };

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -103,7 +103,9 @@ var EditPane = function (options) {
    * @return {Object}
    */
   _getDefaults = function (mainshock) {
-    var mag, ruptureArea, ruptureLength;
+    var mag, 
+        ruptureArea, 
+        ruptureLength;
 
     mag = mainshock.properties.mag;
 

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -103,7 +103,7 @@ var EditPane = function (options) {
    * @return {Object}
    */
   _getDefaults = function (mainshock) {
-    var mag;
+    var mag, ruptureArea, ruptureLength;
 
     mag = mainshock.properties.mag;
 
@@ -112,16 +112,16 @@ var EditPane = function (options) {
      * based on rupture length, which we estimate from the Hanks-Bakun (2014) 
      * magitude-area relation. We round to the nearest 10km via 10*round(0.1*value).
      *
-     * A = 10**(M-4), L(approx) = A**0.7
+     * ruptureArea = 10**(M-4), ruptureLength(approx) = A**0.7
      * 
-     * Aftershock distance = L, historical distance = 1.5*L
+     * Aftershock distance = ruptureLength, historical distance = 1.5*ruptureLength
      */
-      var A = Math.pow(10, mag-4);
-      var L = Math.pow(A, 0.7);
+      ruptureArea = Math.pow(10, mag-4);
+      ruptureLength = Math.pow(ruptureArea, 0.7);
 
     return {
-      'aftershocks-dist': Math.max(5, 10*Math.round(0.1*L)),
-      'historical-dist': Math.max(10, 15*Math.round(0.1*L)),
+      'aftershocks-dist': Math.max(5, 10*Math.round(0.1*ruptureLength)),
+      'historical-dist': Math.max(10, 15*Math.round(0.1*ruptureLength)),
       'historical-years': 10
     };
   };


### PR DESCRIPTION
Use rough estimate of rupture length as a basis for default aftershock and historical seismicity distances.