### PR TITLE
Add minimum magnitude for aftershocks and historical seismicity.

### DIFF
--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -45,6 +45,11 @@
             </label>
             <input type="number" min="1" id="aftershocks-dist" required="required"
               pattern="^[0-9.]+$" value="" />
+            <label for="aftershocks-minmag">
+              <p>Min magnitude</p>
+            </label>
+            <input type="number" min="0" id="aftershocks-minmag" required="required"
+              pattern="^[0-9.]+$" value="0.0" />
           </div>
           <div class="historical">
             <h3>Historical Seismicity</h3>
@@ -58,6 +63,11 @@
             </label>
             <input type="number" min="1" id="historical-years" required="required"
               pattern="^[0-9.]+$" value="10" />
+            <label for="historical-minmag">
+              <p>Min magnitude</p>
+            </label>
+            <input type="number" min="0" id="historical-minmag" required="required"
+              pattern="^[0-9.]+$" value="3.0" />
           </div>
           <div class="meta">
             <input type="reset" class="reset" value="Reset" />

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -139,10 +139,10 @@ var EditPane = function (options) {
 
     return {
       'aftershocks-dist': Math.max(5, 10*Math.round(0.1*ruptureLength)),
+      'aftershocks-minmag': 0.0,
       'historical-dist': Math.max(10, 15*Math.round(0.1*ruptureLength)),
-      'historical-years': 10,
       'historical-minmag': 3.0,
-      'aftershocks-minmag': 3.0,
+      'historical-years': 10,
     };
   };
 

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -140,7 +140,9 @@ var EditPane = function (options) {
     return {
       'aftershocks-dist': Math.max(5, 10*Math.round(0.1*ruptureLength)),
       'historical-dist': Math.max(10, 15*Math.round(0.1*ruptureLength)),
-      'historical-years': 10
+      'historical-years': 10,
+      'historical-minmag': 3.0,
+      'aftershocks-minmag': 3.0,
     };
   };
 

--- a/src/htdocs/js/Features.js
+++ b/src/htdocs/js/Features.js
@@ -234,6 +234,7 @@ var Features = function (options) {
       latitude: _mainshock.geometry.coordinates[1],
       longitude: _mainshock.geometry.coordinates[0],
       maxradiuskm: document.getElementById('aftershocks-dist').value,
+      minmagnitude: document.getElementById('aftershocks-minmag').value,
       starttime: Moment(_mainshock.properties.time + 1000).utc().toISOString()
         .slice(0, -5)
     };
@@ -266,6 +267,7 @@ var Features = function (options) {
       latitude: _mainshock.geometry.coordinates[1],
       longitude: _mainshock.geometry.coordinates[0],
       maxradiuskm: document.getElementById('historical-dist').value,
+      minmagnitude: document.getElementById('historical-minmag').value,
       starttime: Moment(_mainshock.properties.time).utc()
         .subtract(years, 'years').toISOString().slice(0, -5)
     };

--- a/src/htdocs/js/features/EarthquakesLayer.js
+++ b/src/htdocs/js/features/EarthquakesLayer.js
@@ -340,11 +340,14 @@ var EarthquakesLayer = function (options) {
     else {
       formValues = {
         aftershocksDist: document.getElementById('aftershocks-dist').value,
+	aftershocksMinMag: document.getElementById('aftershocks-minmag').value,
         historicalDist: document.getElementById('historical-dist').value,
+	historicalMinMag: document.getElementById('historical-minmag').value,
         historicalYears: document.getElementById('historical-years').value || 0
       };
 
-      summary += '<p>Earthquakes <strong> within ' + formValues[_id + 'Dist'] +
+      summary += '<p><strong>M ' + Number(formValues[_id + 'MinMag']).toFixed(1) + 
+        '+ </strong> earthquakes <strong> within ' + Number(formValues[_id + 'Dist']).toFixed(0) +
         ' km</strong> of mainshock epicenter';
 
       if (_id === 'aftershocks') {


### PR DESCRIPTION
Events in areas with a high rate of seismicity can lead to requests exceeding the max number of events limit (20,000). Using a default value of 3.0 for a minimum magnitude for historical events works quite well. Similar issues could arise with a large event and active aftershock sequence, so use a default minimum magnitude of 0.0 for aftershocks.