### PR TITLE
Fix labeling of magnitudes in table. Fix magnitude displayed in list header.

### DIFF
--- a/src/htdocs/js/features/EarthquakesLayer.js
+++ b/src/htdocs/js/features/EarthquakesLayer.js
@@ -203,7 +203,7 @@ var EarthquakesLayer = function (options) {
           '<th class="total">Total</th>' +
         '</tr>';
       _bins[period].forEach(function(cols, mag) {
-        html += '<tr><td class="rowlabel">M ' + mag + '+</td>';
+        html += '<tr><td class="rowlabel">M ' + mag + '</td>';
         cols.forEach(function(col, i) {
           if (i === 0) { // store total and add to table as last column
             total = '<td class="total">' + col + '</td>';
@@ -369,7 +369,8 @@ var EarthquakesLayer = function (options) {
         summary += _getBinnedTable('Prior');
       }
 
-      summary += '<h3>M ' + _threshold[_id] + '+ Earthquakes (' + count + ')</h3>';
+      summary += '<h3>M ' + Math.max(_threshold[_id], Number(formValues[_id + 'MinMag'])).toFixed(1) + 
+        '+ Earthquakes (' + count + ')</h3>';
       summary += _getEqListTable(_eqList);
     }
 


### PR DESCRIPTION
Magnitudes in tables on summary page are M 0-1, 1-2, etc not M>=1, M>=2,
etc. Use "M 0", "M 1", etc (dropping the "+").

Adding the minimum magnitude for historical earthquakes and aftershocks
means the earthquakes listed in the event list on the summary page may
be limited to larger magnitudes than the implemented default value
(based on mainshock magnitude). Added a fix to display the larger of the
minimum magnitude provided by the user and the default threshold for
listing so that that heading matches the actual data that appears.