### PR TITLE
Fix typo (case) in mouse position filename for map pane css.

### DIFF
--- a/src/htdocs/css/_mapPane.scss
+++ b/src/htdocs/css/_mapPane.scss
@@ -1,4 +1,4 @@
-@import 'mappane/_mousePosition.scss';
+@import 'mappane/_MousePosition.scss';
 @import 'features/_stationsFeature.scss';
 
 #mapPane,


### PR DESCRIPTION
Fix for wrong case in filename for _MousePosition.scss.