### PR TITLE
Fix earthquake id validator to allow ids with fewer digits.

### DIFF
--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -35,7 +35,7 @@
           <div class="mainshock">
             <h3>Mainshock</h3>
             <label for="eqid">
-              <p>Event ID (2 letters followed by 8 characters)</p>
+              <p>Event ID (2 letters followed by 5-8 characters)</p>
             </label>
             <input type="text" id="eqid" required="required"
               pattern="^[a-zA-Z]{2}[a-zA-Z0-9]{8}$" value="" />

--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -38,7 +38,7 @@
               <p>Event ID (2 letters followed by 5-8 characters)</p>
             </label>
             <input type="text" id="eqid" required="required"
-              pattern="^[a-zA-Z]{2}[a-zA-Z0-9]{8}$" value="" />
+              pattern="^[a-zA-Z]{2}[a-zA-Z0-9]{5,8}$" value="" />
           </div>
           <div class="details"></div>
           <div class="aftershocks">

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -245,7 +245,7 @@ var EditPane = function (options) {
       return false;
     }
 
-    // Check eqid format (2 letters followed by 5 characters)
+    // Check eqid format (2 letters followed by 5 or more characters)
     regex = /^[a-zA-Z]{2}[a-zA-Z0-9]{5,}$/;
     if (regex.test(_eqid.value)) {
       return true;

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -245,8 +245,8 @@ var EditPane = function (options) {
       return false;
     }
 
-    // Check eqid format (2 letters followed by 5 or more characters)
-    regex = /^[a-zA-Z]{2}[a-zA-Z0-9]{5,}$/;
+    // Check eqid format (2 letters followed by 5-8 characters)
+    regex = /^[a-zA-Z]{2}[a-zA-Z0-9]{5,8}$/;
     if (regex.test(_eqid.value)) {
       return true;
     }

--- a/src/htdocs/js/EditPane.js
+++ b/src/htdocs/js/EditPane.js
@@ -245,8 +245,8 @@ var EditPane = function (options) {
       return false;
     }
 
-    // Check eqid format (2 letters followed by 8 characters)
-    regex = /^[a-zA-Z]{2}[a-zA-Z0-9]{8}$/;
+    // Check eqid format (2 letters followed by 5 characters)
+    regex = /^[a-zA-Z]{2}[a-zA-Z0-9]{5,}$/;
     if (regex.test(_eqid.value)) {
       return true;
     }


### PR DESCRIPTION
Current earthquake ids are two letters followed by 8 digits, but older ids have fewer digits. Lind reports that for NC the ids have 5-8 or more digits, so this PR modifies the validator to accept two characters plus 5-8 characters. This may need some revision to allow older events in other networks, but this should work in many cases.
  