### PR TITLE
Fix time shift by one event of points in magnitude-time plot for aftershocks.

### DIFF
--- a/src/htdocs/js/PlotsPane.js
+++ b/src/htdocs/js/PlotsPane.js
@@ -370,7 +370,7 @@ var PlotsPane = function (options) {
 
     if (opts.plot === 'cumulative') {
       mode = 'lines+markers';
-      x = data.time;
+      x = data.time.slice(0); // use copy because we modify x for 'aftershocks'
       // Fill y with values from 1 to length of x
       y = Array.from(new Array(x.length), function (val, i) {
         return i + 1;


### PR DESCRIPTION
Both the magnitude vs. time and cumulative number vs. time plots use time for x. The cumulative number of earthquakes plot modifies the x array by prepending the mainshock time; the y array is number which is not used elsewhere so it is safe to prepend values. As a result, we need to use a copy (via slice(0)) of the time array for x so that appending the mainshock time doesn't affect the magnitude vs. time plot.
