### PR TITLE
Fix binning earthquakes by time. Use Math.ceil (round up) not Math.floor.

### DIFF
--- a/src/htdocs/js/features/Earthquakes.js
+++ b/src/htdocs/js/features/Earthquakes.js
@@ -472,14 +472,14 @@ var Earthquakes = function (options) {
 
     // Bin eq totals by magnitude and time / period
     if (_id === 'aftershocks') {
-      days = Math.floor(Moment.duration(eqMoment - _mainshockMoment).asDays());
+      days = Math.ceil(Moment.duration(eqMoment - _mainshockMoment).asDays());
       _addEqToBin(days, magInt, 'first');
 
-      days = Math.floor(Moment.duration(_nowMoment - eqMoment).asDays());
+      days = Math.ceil(Moment.duration(_nowMoment - eqMoment).asDays());
       _addEqToBin(days, magInt, 'past');
     }
     else if (_id === 'historical' || _id === 'foreshocks') {
-      days = Math.floor(Moment.duration(_mainshockMoment - eqMoment).asDays());
+      days = Math.ceil(Moment.duration(_mainshockMoment - eqMoment).asDays());
       _addEqToBin(days, magInt, 'prior');
     }
     // Bin eq totals by magnitude, inclusive (used internally)


### PR DESCRIPTION
Binning earthquakes by time is using Math.floor (which turns 1.9 days into 1.0 days).  We want Math.ceil (which turns 0.9 days into 1.0 days). This results in the correct number for earthquakes within the past day (anything between 0.0 days and 0.99.. days will be <= 1.0 days). 