### PR TITLE
Add install instructions for setting up PHP and PHPRtfLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,54 @@ Earthquake Response app to assist with writing talking points.
 
 First install [node.js](https://nodejs.org/) and [grunt](http://gruntjs.com).
 
+**Note**: You will need PHP and PHPRtfLite in order to generate an earthquake summary RTF file.
+
 1. Clone project
 
-  `git clone https://github.com/shaefner-usgs/esc-eq-response.git`
+```
+git clone https://github.com/shaefner-usgs/esc-eq-response.git
+```
 
 2. Install dependencies
 
-  `cd esc-eq-response`
+```
+cd esc-eq-response
+npm install
 
-  `npm install`
+# If you need to add a CA certificate file:
+npm config set cafile "<path to your certificate file>"
 
-3. Configure app
+# Check the 'cafile'
+npm config get cafile
 
-  `cd esc-eq-response/src/lib`
+```
 
-  `./pre-install` (accept defaults)
+3. Download PHPRtfLite and setup.
 
-4. Run grunt
+```
+cd src-eq-response
+unzip PHPRtfLite-X.X.X.zip
+cd src/htdocs/php && ln -s ../../../PHPRtfLite-X.X.X/lib .
+```
 
-  `cd esc-eq-response`
+4. Configure app
 
-  `grunt`
+```
+cd esc-eq-response/src/lib
+
+# Run configuration script and accept defaults
+./pre-install
+```
+
+5. Run grunt
+
+```
+cd esc-eq-response
+
+# If not using PHP server
+grunt
+
+# If using PHP server
+grunt build
+php -S localhost:9110
+```


### PR DESCRIPTION
Add installation instructions to the README file for setting up PHP and PHPRtfLite, which are used to generate an earthquake summary RTF file.

Also add notes on setting npm config for local certificate files.
